### PR TITLE
Show actual tweet text in the tail -f twitter panel

### DIFF
--- a/docs/data/twitter_posts.json
+++ b/docs/data/twitter_posts.json
@@ -1,0 +1,20 @@
+{
+  "accounts": [
+    {
+      "handle": "Polymarket",
+      "url": "https://x.com/Polymarket",
+      "posts": []
+    },
+    {
+      "handle": "zerohedge",
+      "url": "https://x.com/zerohedge",
+      "posts": []
+    },
+    {
+      "handle": "danielrpopper",
+      "url": "https://x.com/danielrpopper",
+      "posts": []
+    }
+  ],
+  "generated_at": "2026-03-01T19:32:15.293278+00:00"
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,17 +79,15 @@
     </section>
     <aside>
       <h3>tail -f twitter</h3>
-      <a class="twitter-timeline" data-height="400" href="https://twitter.com/Polymarket">Polymarket</a>
-      <a class="twitter-timeline" data-height="400" href="https://twitter.com/zerohedge">zerohedge</a>
-      <a class="twitter-timeline" data-height="400" href="https://twitter.com/danielrpopper">danielrpopper</a>
+      <ul id="list-twitter" class="itemlist">
+        <li class="item meta">Loading posts…</li>
+      </ul>
     </aside>
   </main>
 
   <footer>
     <small>cron@digest ~ emailed at 7:30 AM PT</small>
   </footer>
-
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   <script src="assets/js/app.js?v=4"></script>
 </body>
 </html>

--- a/scripts/fetch_and_build.py
+++ b/scripts/fetch_and_build.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 ROOT = os.path.dirname(os.path.dirname(__file__))
 DOCS = os.path.join(ROOT, "docs")
 DATA_OUT = os.path.join(DOCS, "data", "items.json")
+TWITTER_OUT = os.path.join(DOCS, "data", "twitter_posts.json")
 
 def load_yaml(path):
     with open(path, "r", encoding="utf-8") as f:
@@ -98,6 +99,67 @@ def fetch_feed(url):
     d = feedparser.parse(url)
     return d.entries or []
 
+def fetch_twitter_posts(handles, limit_per_handle=5):
+    instances = [
+        "https://nitter.poast.org",
+        "https://nitter.privacydev.net",
+        "https://nitter.net",
+    ]
+    posts = []
+
+    for tw in (handles or []):
+        handle = (tw.get("handle") or "").strip().lstrip("@")
+        if not handle:
+            continue
+
+        entries = []
+        for base in instances:
+            try:
+                entries = fetch_feed(f"{base}/{handle}/rss")
+                if entries:
+                    break
+            except Exception:
+                continue
+
+        if not entries:
+            print(f"[warn] no twitter posts found for @{handle}")
+            posts.append({
+                "handle": handle,
+                "url": f"https://x.com/{handle}",
+                "posts": [],
+            })
+            continue
+
+        normalized = []
+        for e in entries[:limit_per_handle]:
+            title = BeautifulSoup(e.get("title") or "", "html.parser").get_text(" ", strip=True)
+            summary = BeautifulSoup(e.get("summary") or "", "html.parser").get_text(" ", strip=True)
+            text = title or summary
+            if ": " in text:
+                text = text.split(": ", 1)[1]
+
+            published = e.get("published_parsed") or e.get("updated_parsed")
+            if published:
+                dt = datetime.utcfromtimestamp(time.mktime(published)).replace(tzinfo=timezone.utc)
+                published_iso = dt.isoformat()
+            else:
+                published_iso = datetime.now(tz=timezone.utc).isoformat()
+
+            normalized.append({
+                "id": hashlib.md5(((e.get("link") or "") + text).encode("utf-8")).hexdigest(),
+                "url": e.get("link") or f"https://x.com/{handle}",
+                "text": text,
+                "published": published_iso,
+            })
+
+        posts.append({
+            "handle": handle,
+            "url": f"https://x.com/{handle}",
+            "posts": normalized,
+        })
+
+    return posts
+
 def main():
     feeds_cfg = load_yaml(os.path.join(ROOT, "feeds.yml")) or {}
     themes_cfg = load_yaml(os.path.join(ROOT, "themes.yml")) or {}
@@ -160,6 +222,11 @@ def main():
     with open(DATA_OUT, "w", encoding="utf-8") as f:
         json.dump({"items": items, "generated_at": datetime.now(timezone.utc).isoformat()}, f, ensure_ascii=False, indent=2)
     print(f"Wrote {len(items)} items to {DATA_OUT}")
+
+    twitter_posts = fetch_twitter_posts(feeds_cfg.get("twitter_embeds"), limit_per_handle=5)
+    with open(TWITTER_OUT, "w", encoding="utf-8") as f:
+        json.dump({"accounts": twitter_posts, "generated_at": datetime.now(timezone.utc).isoformat()}, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {len(twitter_posts)} twitter accounts to {TWITTER_OUT}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Replace the static Twitter widget sidebar (profile links only) with an app-rendered list so actual post text, timestamps and post links can be shown inline.
- Provide a deterministic build-time payload so the UI can load recent posts without relying on the embedded `platform.twitter.com/widgets.js` script.

### Description
- Replaced the timeline embeds with a `#list-twitter` container in `docs/index.html` to host rendered posts.
- Added client-side loading and a `renderTwitter` renderer in `docs/assets/js/app.js` that fetches `data/twitter_posts.json` and shows post text, timestamp and links to each post.
- Extended `scripts/fetch_and_build.py` with `fetch_twitter_posts` that attempts multiple Nitter RSS instances, normalizes entries and writes `docs/data/twitter_posts.json` via the new `TWITTER_OUT` path.
- Added an initial `docs/data/twitter_posts.json` scaffold so the UI has deterministic data to load when the site is built.

### Testing
- Ran `python -m py_compile scripts/fetch_and_build.py` which succeeded.
- Validated the generated JSON with `python -m json.tool docs/data/twitter_posts.json` which succeeded.
- Ran `python scripts/fetch_and_build.py` which completed but emitted warnings due to external proxy restrictions in the execution environment and produced `twitter_posts.json` with empty `posts` arrays for accounts.
- Served the `docs` folder locally with `python -m http.server 8000` and captured a screenshot to validate the updated sidebar rendering which displayed the new `tail -f twitter` list container successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a493d3c83c8321be6839565c1041d5)