### PR TITLE
Add RoundtableSpace to tail X/Twitter feed

### DIFF
--- a/docs/data/twitter_posts.json
+++ b/docs/data/twitter_posts.json
@@ -14,6 +14,11 @@
       "handle": "danielrpopper",
       "url": "https://x.com/danielrpopper",
       "posts": []
+    },
+    {
+      "handle": "RoundtableSpace",
+      "url": "https://x.com/RoundtableSpace",
+      "posts": []
     }
   ],
   "generated_at": "2026-03-01T19:32:15.293278+00:00"

--- a/feeds.yml
+++ b/feeds.yml
@@ -25,3 +25,4 @@ twitter_embeds:
   - handle: Polymarket
   - handle: zerohedge
   - handle: danielrpopper
+  - handle: RoundtableSpace


### PR DESCRIPTION
### Motivation
- Include the requested X/Twitter account in the tail section so the site shows `RoundtableSpace` in the `tail -f twitter` aside.

### Description
- Updated `feeds.yml` to add `RoundtableSpace` under `twitter_embeds` and updated `docs/data/twitter_posts.json` to include the account with `"url": "https://x.com/RoundtableSpace"` and an empty `posts` array.

### Testing
- Validated `docs/data/twitter_posts.json` with `python3 -m json.tool`, validated `feeds.yml` with `yaml.safe_load` in `python`, served `docs/` with `python3 -m http.server 4173` and captured a Playwright screenshot for visual verification; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49e16e7088321b572211e8c532cd5)